### PR TITLE
Scaled rates

### DIFF
--- a/src/market.rs
+++ b/src/market.rs
@@ -167,7 +167,7 @@ impl LogsProvider for EthersProvider {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RateCard {
     pub instance: String,
-    pub min_rate: u128,
+    pub min_rate: U256,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -180,7 +180,7 @@ pub struct RegionalRates {
 pub struct GBRateCard {
     pub region: String,
     pub region_code: String,
-    pub rate: u128,
+    pub rate: U256,
 }
 
 pub async fn run(

--- a/src/market.rs
+++ b/src/market.rs
@@ -167,7 +167,7 @@ impl LogsProvider for EthersProvider {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RateCard {
     pub instance: String,
-    pub min_rate: i64,
+    pub min_rate: u128,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/market.rs
+++ b/src/market.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use ethers::abi::{AbiDecode, AbiEncode};
 use ethers::prelude::*;
+use ethers::types::serde_helpers::deserialize_stringified_numeric;
 use ethers::utils::keccak256;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -167,6 +168,7 @@ impl LogsProvider for EthersProvider {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RateCard {
     pub instance: String,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub min_rate: U256,
 }
 
@@ -180,6 +182,7 @@ pub struct RegionalRates {
 pub struct GBRateCard {
     pub region: String,
     pub region_code: String,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub rate: U256,
 }
 

--- a/src/market.rs
+++ b/src/market.rs
@@ -787,7 +787,7 @@ impl JobState {
                     if entry.region == self.region {
                         for card in &entry.rate_cards {
                             if card.instance == self.instance_type {
-                                self.min_rate = U256::from(card.min_rate);
+                                self.min_rate = card.min_rate;
                                 supported = true;
                                 break;
                             }
@@ -816,8 +816,7 @@ impl JobState {
                             let gb_cost = entry.rate;
                             let bandwidth_rate = self.rate - self.min_rate;
 
-                            self.bandwidth = ((bandwidth_rate * 1024 * 8 / U256::from(gb_cost))
-                                as U256)
+                            self.bandwidth = ((bandwidth_rate * 1024 * 8 / gb_cost) as U256)
                                 .clamp(U256::zero(), u64::MAX.into())
                                 .low_u64();
                             break;


### PR DESCRIPTION
Rates files now have strings in place of numbers. Fixed parsing.

Breaking change: The server now returns the numbers as a hex string.