### PR TITLE
Bandwidth Fix

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -342,6 +342,18 @@ impl Aws {
             }
 
             if !is_qdisc_config_set {
+                // remove previously defined rules
+                let (_, stderr) = Self::ssh_exec(
+                    sess,
+                    &("sudo tc qdisc del dev ".to_owned() + &interface + " root"),
+                )?;
+                if !stderr.is_empty() {
+                    println!("{stderr}");
+                    return Err(anyhow!(
+                        "Error removing network interface qdisc configuration: {stderr}"
+                    ));
+                }
+
                 let (_, stderr) = Self::ssh_exec(
                     sess,
                     &("sudo tc qdisc add dev ".to_owned()

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,9 +104,15 @@ async fn parse_bandwidth_rates_file(filepath: String) -> Result<Vec<market::GBRa
 }
 
 async fn get_chain_id_from_rpc_url(url: String) -> Result<String> {
-    let provider = Provider::<Ws>::connect(url).await.context("Failed to connect to rpc to fetch chain_id")?;
-    let hex_chain_id: String = provider.request("eth_chainId", ()).await.context("Failed to fetch chain_id")?;
-    let chain_id = u64::from_str_radix(&hex_chain_id[2..], 16).context("Failed to convert chain_id to u64")?;
+    let provider = Provider::<Ws>::connect(url)
+        .await
+        .context("Failed to connect to rpc to fetch chain_id")?;
+    let hex_chain_id: String = provider
+        .request("eth_chainId", ())
+        .await
+        .context("Failed to fetch chain_id")?;
+    let chain_id =
+        u64::from_str_radix(&hex_chain_id[2..], 16).context("Failed to convert chain_id to u64")?;
 
     Ok(chain_id.to_string())
 }
@@ -182,7 +188,9 @@ pub async fn main() -> Result<()> {
         address_whitelist,
         address_blacklist,
         cli.contract,
-        get_chain_id_from_rpc_url(cli.rpc).await.context("Failed to fetch chain_id")?,
+        get_chain_id_from_rpc_url(cli.rpc)
+            .await
+            .context("Failed to fetch chain_id")?,
     )
     .await;
 


### PR DESCRIPTION
### Issue
If the bandwidth is modified, then while checking if the rules for the network configuration exist, it is being checked for the exact updated bandwidth. For modified bandwidth, this will always give false, and we will proceed to add the rule for the updated bandwidth, without removing the previous bandwidth rule

### Solution
Keep the check the same and if it fails. remove all rules and then add the rule for the required bandwidth.