### PR TITLE
Bugfix: Consistent job identity everywhere

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1504,7 +1504,7 @@ impl InfraProvider for Aws {
 
     async fn run_enclave(
         &mut self,
-        job: String,
+        job: &JobId,
         instance_id: &str,
         family: &str,
         region: &str,
@@ -1514,7 +1514,7 @@ impl InfraProvider for Aws {
         bandwidth: u64,
     ) -> Result<()> {
         self.run_enclave_impl(
-            &job,
+            &job.id,
             family,
             instance_id,
             region,

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1089,7 +1089,7 @@ impl Aws {
 
     async fn allocate_ip_addr(&self, job: &JobId, region: &str) -> Result<(String, String)> {
         let (exist, alloc_id, public_ip) = self
-            .get_job_elastic_ip(&job, region)
+            .get_job_elastic_ip(job, region)
             .await
             .context("could not get elastic ip for job")?;
 

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 use tokio::time::{sleep, Duration};
 use whoami::username;
 
-use crate::market::InfraProvider;
+use crate::market::{InfraProvider, Job};
 
 #[derive(Clone)]
 pub struct Aws {
@@ -1460,28 +1460,26 @@ impl InfraProvider for Aws {
     async fn spin_up(
         &mut self,
         eif_url: &str,
-        job: String,
+        job: Job,
         instance_type: &str,
         family: &str,
         region: &str,
         req_mem: i64,
         req_vcpu: i32,
         bandwidth: u64,
-        contract_address: String,
-        chain_id: String,
     ) -> Result<String> {
         let instance = self
             .spin_up_instance(
                 eif_url,
-                job,
+                job.id,
                 instance_type,
                 family,
                 region,
                 req_mem,
                 req_vcpu,
                 bandwidth,
-                contract_address,
-                chain_id,
+                job.contract_address,
+                job.chain_id,
             )
             .await
             .context("could not spin up instance")?;

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1237,7 +1237,6 @@ impl Aws {
         region: &str,
         req_mem: i64,
         req_vcpu: i32,
-        bandwidth: u64,
         contract_address: String,
         chain_id: String,
     ) -> Result<String> {
@@ -1301,18 +1300,7 @@ impl Aws {
             .context("could not launch instance")?;
         sleep(Duration::from_secs(100)).await;
 
-        let res = self
-            .post_spin_up(
-                image_url,
-                job.clone(),
-                family,
-                &instance,
-                region,
-                req_mem,
-                req_vcpu,
-                bandwidth,
-            )
-            .await;
+        let res = self.post_spin_up(job.clone(), &instance, region).await;
 
         if let Err(err) = res {
             println!("error during post spin up: {err:?}");
@@ -1324,17 +1312,7 @@ impl Aws {
         Ok(instance)
     }
 
-    async fn post_spin_up(
-        &self,
-        image_url: &str,
-        job: String,
-        family: &str,
-        instance: &str,
-        region: &str,
-        req_mem: i64,
-        req_vcpu: i32,
-        bandwidth: u64,
-    ) -> Result<()> {
+    async fn post_spin_up(&self, job: String, instance: &str, region: &str) -> Result<()> {
         let (alloc_id, ip) = self
             .allocate_ip_addr(job.clone(), region)
             .await
@@ -1461,7 +1439,7 @@ impl InfraProvider for Aws {
         region: &str,
         req_mem: i64,
         req_vcpu: i32,
-        bandwidth: u64,
+        _bandwidth: u64,
     ) -> Result<String> {
         let instance = self
             .spin_up_instance(
@@ -1472,7 +1450,6 @@ impl InfraProvider for Aws {
                 region,
                 req_mem,
                 req_vcpu,
-                bandwidth,
                 job.contract.clone(),
                 job.chain.clone(),
             )

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1464,20 +1464,20 @@ impl InfraProvider for Aws {
             .context("could not spin down instance")
     }
 
-    async fn get_job_instance(&self, job: &str, region: &str) -> Result<(bool, String, String)> {
-        self.get_job_instance_id(job, region)
+    async fn get_job_instance(&self, job: &JobId, region: &str) -> Result<(bool, String, String)> {
+        self.get_job_instance_id(&job.id, region)
             .await
             .context("could not get instance id for job")
     }
 
-    async fn get_job_ip(&self, job_id: &str, region: &str) -> Result<String> {
+    async fn get_job_ip(&self, job: &JobId, region: &str) -> Result<String> {
         let instance = self
-            .get_job_instance(job_id, region)
+            .get_job_instance(job, region)
             .await
             .context("could not get instance id for job instance ip")?;
 
         if !instance.0 {
-            return Err(anyhow!("Instance not found for job - {job_id}"));
+            return Err(anyhow!("Instance not found for job - {}", job.id));
         }
 
         self.get_instance_ip(&instance.1, region)

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1478,8 +1478,8 @@ impl InfraProvider for Aws {
                 req_mem,
                 req_vcpu,
                 bandwidth,
-                job.contract_address,
-                job.chain_id,
+                job.contract,
+                job.chain,
             )
             .await
             .context("could not spin up instance")?;

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1344,11 +1344,6 @@ impl Aws {
         self.associate_address(instance, &alloc_id, region)
             .await
             .context("could not associate ip address")?;
-        self.run_enclave_impl(
-            &job, family, instance, region, image_url, req_vcpu, req_mem, bandwidth,
-        )
-        .await
-        .context("could not run enclave")?;
         Ok(())
     }
 

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1460,7 +1460,7 @@ impl InfraProvider for Aws {
     async fn spin_up(
         &mut self,
         eif_url: &str,
-        job: Job,
+        job: &Job,
         instance_type: &str,
         family: &str,
         region: &str,
@@ -1471,15 +1471,15 @@ impl InfraProvider for Aws {
         let instance = self
             .spin_up_instance(
                 eif_url,
-                job.id,
+                job.id.clone(),
                 instance_type,
                 family,
                 region,
                 req_mem,
                 req_vcpu,
                 bandwidth,
-                job.contract,
-                job.chain,
+                job.contract.clone(),
+                job.chain.clone(),
             )
             .await
             .context("could not spin up instance")?;

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 use tokio::time::{sleep, Duration};
 use whoami::username;
 
-use crate::market::{InfraProvider, Job};
+use crate::market::{InfraProvider, JobId};
 
 #[derive(Clone)]
 pub struct Aws {
@@ -1433,7 +1433,7 @@ impl InfraProvider for Aws {
     async fn spin_up(
         &mut self,
         eif_url: &str,
-        job: &Job,
+        job: &JobId,
         instance_type: &str,
         family: &str,
         region: &str,
@@ -1458,7 +1458,7 @@ impl InfraProvider for Aws {
         Ok(instance)
     }
 
-    async fn spin_down(&mut self, instance_id: &str, job: &Job, region: &str) -> Result<()> {
+    async fn spin_down(&mut self, instance_id: &str, job: &JobId, region: &str) -> Result<()> {
         self.spin_down_instance(instance_id, &job.id, region)
             .await
             .context("could not spin down instance")

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1458,8 +1458,8 @@ impl InfraProvider for Aws {
         Ok(instance)
     }
 
-    async fn spin_down(&mut self, instance_id: &str, job: String, region: &str) -> Result<()> {
-        self.spin_down_instance(instance_id, &job, region)
+    async fn spin_down(&mut self, instance_id: &str, job: &Job, region: &str) -> Result<()> {
+        self.spin_down_instance(instance_id, &job.id, region)
             .await
             .context("could not spin down instance")
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,16 @@ pub async fn main() -> Result<()> {
     let address_whitelist: &'static [String] = Box::leak(address_whitelist_vec.into_boxed_slice());
     let address_blacklist: &'static [String] = Box::leak(address_blacklist_vec.into_boxed_slice());
     let regions: &'static [String] = Box::leak(regions.into_boxed_slice());
+    let chain = get_chain_id_from_rpc_url(cli.rpc.clone())
+        .await
+        .context("Failed to fetch chain_id")?;
+
+    let job_id = market::JobId {
+        id: H256::zero().encode_hex(),
+        operator: cli.provider.clone(),
+        contract: cli.contract.clone(),
+        chain,
+    };
 
     tokio::spawn(server::serve(
         aws.clone(),
@@ -174,12 +184,12 @@ pub async fn main() -> Result<()> {
         compute_rates,
         bandwidth_rates,
         SocketAddr::from(([0, 0, 0, 0], 8080)),
+        job_id.clone(),
     ));
 
     let ethers = market::EthersProvider {
         contract: cli
             .contract
-            .clone()
             .parse::<Address>()
             .context("failed to parse contract address")?,
         provider: cli
@@ -191,20 +201,13 @@ pub async fn main() -> Result<()> {
     market::run(
         aws,
         ethers,
-        cli.rpc.clone(),
+        cli.rpc,
         regions,
         compute_rates,
         bandwidth_rates,
         address_whitelist,
         address_blacklist,
-        market::JobId {
-            id: H256::zero().encode_hex(),
-            operator: cli.provider,
-            contract: cli.contract,
-            chain: get_chain_id_from_rpc_url(cli.rpc)
-                .await
-                .context("Failed to fetch chain_id")?,
-        },
+        job_id,
     )
     .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use cp::server;
 use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
+use ethers::abi::AbiEncode;
 use ethers::prelude::*;
 use ethers::providers::{Provider, Ws};
 use std::fs;
@@ -196,10 +197,14 @@ pub async fn main() -> Result<()> {
         bandwidth_rates,
         address_whitelist,
         address_blacklist,
-        cli.contract,
-        get_chain_id_from_rpc_url(cli.rpc)
-            .await
-            .context("Failed to fetch chain_id")?,
+        market::JobId {
+            id: H256::zero().encode_hex(),
+            operator: cli.provider,
+            contract: cli.contract,
+            chain: get_chain_id_from_rpc_url(cli.rpc)
+                .await
+                .context("Failed to fetch chain_id")?,
+        },
     )
     .await;
 

--- a/src/market.rs
+++ b/src/market.rs
@@ -71,7 +71,7 @@ pub trait InfraProvider {
 
     fn run_enclave(
         &mut self,
-        job: String,
+        job: &JobId,
         instance_id: &str,
         family: &str,
         region: &str,
@@ -142,7 +142,7 @@ where
 
     async fn run_enclave(
         &mut self,
-        job: String,
+        job: &JobId,
         instance_id: &str,
         family: &str,
         region: &str,
@@ -571,7 +571,13 @@ impl<'a> JobState<'a> {
                                 println!("job {job}: enclave not running on the instance, running the enclave");
                                 let res = infra_provider
                                     .run_enclave(
-                                        job.encode_hex(),
+                                        &JobId {
+                                            id: job.encode_hex(),
+                                            // TODO: change this to be the operator address
+                                            operator: self.contract_address.clone(),
+                                            contract: self.contract_address.clone(),
+                                            chain: self.chain_id.clone(),
+                                        },
                                         &self.instance_id,
                                         &self.family,
                                         &self.region,
@@ -749,7 +755,13 @@ impl<'a> JobState<'a> {
             // try to run the enclave, ignore errors
             let res = infra_provider
                 .run_enclave(
-                    job.encode_hex(),
+                    &JobId {
+                        id: job.encode_hex(),
+                        // TODO: change this to be the operator address
+                        operator: self.contract_address.clone(),
+                        contract: self.contract_address.clone(),
+                        chain: self.chain_id.clone(),
+                    },
                     &self.instance_id,
                     &self.family,
                     &self.region,

--- a/src/market.rs
+++ b/src/market.rs
@@ -24,9 +24,9 @@ use ethers::types::Log;
 // This is needed to cleanly support multiple operators/contracts/chains at the infra level
 pub struct Job {
     pub id: String,
-    pub operator_address: String,
-    pub contract_address: String,
-    pub chain_id: String,
+    pub operator: String,
+    pub contract: String,
+    pub chain: String,
 }
 
 pub trait InfraProvider {
@@ -708,9 +708,9 @@ impl<'a> JobState<'a> {
                     Job {
                         id: job.encode_hex(),
                         // TODO: change this to be the operator address
-                        operator_address: self.contract_address.clone(),
-                        contract_address: self.contract_address.clone(),
-                        chain_id: self.chain_id.clone(),
+                        operator: self.contract_address.clone(),
+                        contract: self.contract_address.clone(),
+                        chain: self.chain_id.clone(),
                     },
                     self.instance_type.as_str(),
                     self.family.as_str(),

--- a/src/market.rs
+++ b/src/market.rs
@@ -22,7 +22,7 @@ use ethers::types::Log;
 
 // Identify jobs not only by the id, but also by the operator, contract and the chain
 // This is needed to cleanly support multiple operators/contracts/chains at the infra level
-pub struct Job {
+pub struct JobId {
     pub id: String,
     pub operator: String,
     pub contract: String,
@@ -33,7 +33,7 @@ pub trait InfraProvider {
     fn spin_up(
         &mut self,
         eif_url: &str,
-        job: &Job,
+        job: &JobId,
         instance_type: &str,
         family: &str,
         region: &str,
@@ -45,7 +45,7 @@ pub trait InfraProvider {
     fn spin_down(
         &mut self,
         instance_id: &str,
-        job: &Job,
+        job: &JobId,
         region: &str,
     ) -> impl Future<Output = Result<()>> + Send;
 
@@ -98,7 +98,7 @@ where
     async fn spin_up(
         &mut self,
         eif_url: &str,
-        job: &Job,
+        job: &JobId,
         instance_type: &str,
         family: &str,
         region: &str,
@@ -120,7 +120,7 @@ where
             .await
     }
 
-    async fn spin_down(&mut self, instance_id: &str, job: &Job, region: &str) -> Result<()> {
+    async fn spin_down(&mut self, instance_id: &str, job: &JobId, region: &str) -> Result<()> {
         (**self).spin_down(instance_id, job, region).await
     }
 
@@ -691,7 +691,7 @@ impl<'a> JobState<'a> {
                     let res = infra_provider
                         .spin_down(
                             &instance,
-                            &Job {
+                            &JobId {
                                 id: job.encode_hex(),
                                 // TODO: change this to be the operator address
                                 operator: self.contract_address.clone(),
@@ -715,7 +715,7 @@ impl<'a> JobState<'a> {
             let res = infra_provider
                 .spin_up(
                     self.eif_url.as_str(),
-                    &Job {
+                    &JobId {
                         id: job.encode_hex(),
                         // TODO: change this to be the operator address
                         operator: self.contract_address.clone(),
@@ -768,7 +768,7 @@ impl<'a> JobState<'a> {
             let res = infra_provider
                 .spin_down(
                     &instance,
-                    &Job {
+                    &JobId {
                         id: job.encode_hex(),
                         // TODO: change this to be the operator address
                         operator: self.contract_address.clone(),

--- a/src/market.rs
+++ b/src/market.rs
@@ -45,7 +45,7 @@ pub trait InfraProvider {
     fn spin_down(
         &mut self,
         instance_id: &str,
-        job: String,
+        job: &Job,
         region: &str,
     ) -> impl Future<Output = Result<()>> + Send;
 
@@ -120,7 +120,7 @@ where
             .await
     }
 
-    async fn spin_down(&mut self, instance_id: &str, job: String, region: &str) -> Result<()> {
+    async fn spin_down(&mut self, instance_id: &str, job: &Job, region: &str) -> Result<()> {
         (**self).spin_down(instance_id, job, region).await
     }
 
@@ -689,7 +689,17 @@ impl<'a> JobState<'a> {
                     // instance unhealthy, terminate
                     println!("job {job}: found existing unhealthy instance: {instance}");
                     let res = infra_provider
-                        .spin_down(&instance, job.encode_hex(), &self.region)
+                        .spin_down(
+                            &instance,
+                            &Job {
+                                id: job.encode_hex(),
+                                // TODO: change this to be the operator address
+                                operator: self.contract_address.clone(),
+                                contract: self.contract_address.clone(),
+                                chain: self.chain_id.clone(),
+                            },
+                            &self.region,
+                        )
                         .await;
                     if let Err(err) = res {
                         println!("job {job}: ERROR failed to terminate instance, {err:?}");
@@ -756,7 +766,17 @@ impl<'a> JobState<'a> {
             // terminate instance
             println!("job {job}: terminating existing instance: {instance}");
             let res = infra_provider
-                .spin_down(&instance, job.encode_hex(), &self.region)
+                .spin_down(
+                    &instance,
+                    &Job {
+                        id: job.encode_hex(),
+                        // TODO: change this to be the operator address
+                        operator: self.contract_address.clone(),
+                        contract: self.contract_address.clone(),
+                        chain: self.chain_id.clone(),
+                    },
+                    &self.region,
+                )
                 .await;
             if let Err(err) = res {
                 println!("job {job}: ERROR failed to terminate instance, {err:?}");

--- a/src/market.rs
+++ b/src/market.rs
@@ -33,7 +33,7 @@ pub trait InfraProvider {
     fn spin_up(
         &mut self,
         eif_url: &str,
-        job: Job,
+        job: &Job,
         instance_type: &str,
         family: &str,
         region: &str,
@@ -98,7 +98,7 @@ where
     async fn spin_up(
         &mut self,
         eif_url: &str,
-        job: Job,
+        job: &Job,
         instance_type: &str,
         family: &str,
         region: &str,
@@ -705,7 +705,7 @@ impl<'a> JobState<'a> {
             let res = infra_provider
                 .spin_up(
                     self.eif_url.as_str(),
-                    Job {
+                    &Job {
                         id: job.encode_hex(),
                         // TODO: change this to be the operator address
                         operator: self.contract_address.clone(),

--- a/src/market.rs
+++ b/src/market.rs
@@ -1359,15 +1359,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1443,15 +1446,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1528,15 +1534,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1616,15 +1625,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1700,15 +1712,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1741,15 +1756,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1782,15 +1800,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1823,15 +1844,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1864,15 +1888,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1905,15 +1932,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1946,15 +1976,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -1988,15 +2021,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -2075,15 +2111,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -2159,7 +2198,12 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
@@ -2168,8 +2212,6 @@ mod tests {
                 "0x000000000000000000000000000000000000000000000000f020b3e5fc7a49ec".to_string(),
             ]),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -2245,7 +2287,12 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
@@ -2254,8 +2301,6 @@ mod tests {
                 "0x000000000000000000000000000000000000000000000000f020c4f6gc7a56ce".to_string(),
             ]),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -2288,7 +2333,12 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
@@ -2297,8 +2347,6 @@ mod tests {
             &Vec::from([
                 "0x000000000000000000000000000000000000000000000000f020b3e5fc7a49ec".to_string(),
             ]),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -2331,7 +2379,12 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
@@ -2340,8 +2393,6 @@ mod tests {
             &Vec::from([
                 "0x000000000000000000000000000000000000000000000000f020b3e5fc7a49ece".to_string(),
             ]),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -2616,15 +2667,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -2702,15 +2756,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 
@@ -2745,15 +2802,18 @@ mod tests {
         let res = market::job_manager_once(
             job_stream,
             &mut aws,
-            job_num,
+            market::JobId {
+                id: job_num.encode_hex(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
             &["ap-south-1".into()],
             300,
             &test::get_rates(),
             &test::get_gb_rates(),
             &Vec::new(),
             &Vec::new(),
-            "xyz".into(),
-            "123".into(),
         )
         .await;
 

--- a/src/market.rs
+++ b/src/market.rs
@@ -1394,8 +1394,10 @@ mod tests {
         assert_eq!(res, 0);
         println!("{:?}", aws.outcomes);
         let spin_up_tv_sec: Instant;
+        let instance_id: String;
         if let TestAwsOutcome::SpinUp(out) = &aws.outcomes[0] {
             spin_up_tv_sec = out.time;
+            instance_id = out.instance_id.clone();
             assert!(
                 H256::from_str(&out.job).unwrap() == job_num
                     && out.instance_type == "c6a.xlarge"
@@ -1412,7 +1414,22 @@ mod tests {
             panic!();
         };
 
-        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[1] {
+        if let TestAwsOutcome::RunEnclave(out) = &aws.outcomes[1] {
+            assert!(
+                H256::from_str(&out.job).unwrap() == job_num
+                    && out.instance_id == instance_id
+                    && out.family == "salmon"
+                    && out.region == "ap-south-1"
+                    && out.req_mem == 4096
+                    && out.req_vcpu == 2
+                    && out.bandwidth == 76
+                    && out.eif_url == "https://example.com/enclave.eif"
+            )
+        } else {
+            panic!();
+        };
+
+        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[2] {
             assert_eq!((out.time - spin_up_tv_sec).as_secs(), 1);
             assert!(H256::from_str(&out.job).unwrap() == job_num && out.region == *"ap-south-1")
         } else {
@@ -1461,25 +1478,40 @@ mod tests {
         assert_eq!(res, 0);
         println!("{:?}", aws.outcomes);
         let spin_up_tv_sec: Instant;
+        let instance_id: String;
         if let TestAwsOutcome::SpinUp(out) = &aws.outcomes[0] {
             spin_up_tv_sec = out.time;
+            instance_id = out.instance_id.clone();
             assert!(
                 H256::from_str(&out.job).unwrap() == job_num
-                    && out.instance_type == "c6a.xlarge"
+                    && out.instance_id == instance_id
                     && out.family == "tuna"
                     && out.region == "ap-south-1"
                     && out.req_mem == 4096
                     && out.req_vcpu == 2
                     && out.bandwidth == 76
                     && out.eif_url == "https://example.com/enclave.eif"
-                    && out.contract_address == "xyz"
-                    && out.chain_id == "123"
             )
         } else {
             panic!();
         };
 
-        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[1] {
+        if let TestAwsOutcome::RunEnclave(out) = &aws.outcomes[1] {
+            assert!(
+                H256::from_str(&out.job).unwrap() == job_num
+                    && out.instance_id == instance_id
+                    && out.family == "tuna"
+                    && out.region == "ap-south-1"
+                    && out.req_mem == 4096
+                    && out.req_vcpu == 2
+                    && out.bandwidth == 76
+                    && out.eif_url == "https://example.com/enclave.eif"
+            )
+        } else {
+            panic!();
+        };
+
+        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[2] {
             assert_eq!((out.time - spin_up_tv_sec).as_secs(), 1);
             assert!(H256::from_str(&out.job).unwrap() == job_num && out.region == *"ap-south-1")
         } else {
@@ -1531,8 +1563,10 @@ mod tests {
         assert_eq!(res, 0);
         println!("{:?}", aws.outcomes);
         let spin_up_tv_sec: Instant;
+        let instance_id: String;
         if let TestAwsOutcome::SpinUp(out) = &aws.outcomes[0] {
             spin_up_tv_sec = out.time;
+            instance_id = out.instance_id.clone();
             assert!(
                 H256::from_str(&out.job).unwrap() == job_num
                     && out.instance_type == "c6a.xlarge"
@@ -1549,7 +1583,22 @@ mod tests {
             panic!();
         };
 
-        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[1] {
+        if let TestAwsOutcome::RunEnclave(out) = &aws.outcomes[1] {
+            assert!(
+                H256::from_str(&out.job).unwrap() == job_num
+                    && out.instance_id == instance_id
+                    && out.family == "salmon"
+                    && out.region == "ap-south-1"
+                    && out.req_mem == 4096
+                    && out.req_vcpu == 2
+                    && out.bandwidth == 76
+                    && out.eif_url == "https://example.com/enclave.eif"
+            )
+        } else {
+            panic!();
+        };
+
+        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[2] {
             assert_eq!((out.time - spin_up_tv_sec).as_secs(), 205);
             assert!(H256::from_str(&out.job).unwrap() == job_num && out.region == *"ap-south-1")
         } else {
@@ -1602,8 +1651,10 @@ mod tests {
         assert_eq!(res, 0);
         println!("{:?}", aws.outcomes);
         let spin_up_tv_sec: Instant;
+        let instance_id: String;
         if let TestAwsOutcome::SpinUp(out) = &aws.outcomes[0] {
             spin_up_tv_sec = out.time;
+            instance_id = out.instance_id.clone();
             assert!(
                 H256::from_str(&out.job).unwrap() == job_num
                     && out.instance_type == "c6a.xlarge"
@@ -1620,7 +1671,22 @@ mod tests {
             panic!();
         };
 
-        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[1] {
+        if let TestAwsOutcome::RunEnclave(out) = &aws.outcomes[1] {
+            assert!(
+                H256::from_str(&out.job).unwrap() == job_num
+                    && out.instance_id == instance_id
+                    && out.family == "salmon"
+                    && out.region == "ap-south-1"
+                    && out.req_mem == 4096
+                    && out.req_vcpu == 2
+                    && out.bandwidth == 76
+                    && out.eif_url == "https://example.com/enclave.eif"
+            )
+        } else {
+            panic!();
+        };
+
+        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[2] {
             assert_eq!((out.time - spin_up_tv_sec).as_secs(), 205);
             assert!(H256::from_str(&out.job).unwrap() == job_num && out.region == *"ap-south-1")
         } else {
@@ -1957,8 +2023,10 @@ mod tests {
         assert_eq!(res, 0);
         println!("{:?}", aws.outcomes);
         let spin_up_tv_sec: Instant;
+        let instance_id: String;
         if let TestAwsOutcome::SpinUp(out) = &aws.outcomes[0] {
             spin_up_tv_sec = out.time;
+            instance_id = out.instance_id.clone();
             assert!(
                 H256::from_str(&out.job).unwrap() == job_num
                     && out.instance_type == "c6a.xlarge"
@@ -1975,7 +2043,22 @@ mod tests {
             panic!();
         };
 
-        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[1] {
+        if let TestAwsOutcome::RunEnclave(out) = &aws.outcomes[1] {
+            assert!(
+                H256::from_str(&out.job).unwrap() == job_num
+                    && out.instance_id == instance_id
+                    && out.family == "salmon"
+                    && out.region == "ap-south-1"
+                    && out.req_mem == 4096
+                    && out.req_vcpu == 2
+                    && out.bandwidth == 76
+                    && out.eif_url == "https://example.com/enclave.eif"
+            )
+        } else {
+            panic!();
+        };
+
+        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[2] {
             assert_eq!((out.time - spin_up_tv_sec).as_secs(), 50);
             assert!(H256::from_str(&out.job).unwrap() == job_num && out.region == *"ap-south-1")
         } else {
@@ -2027,8 +2110,10 @@ mod tests {
         assert_eq!(res, 0);
         println!("{:?}", aws.outcomes);
         let spin_up_tv_sec: Instant;
+        let instance_id: String;
         if let TestAwsOutcome::SpinUp(out) = &aws.outcomes[0] {
             spin_up_tv_sec = out.time;
+            instance_id = out.instance_id.clone();
             assert!(
                 H256::from_str(&out.job).unwrap() == job_num
                     && out.instance_type == "c6a.xlarge"
@@ -2045,7 +2130,22 @@ mod tests {
             panic!();
         };
 
-        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[1] {
+        if let TestAwsOutcome::RunEnclave(out) = &aws.outcomes[1] {
+            assert!(
+                H256::from_str(&out.job).unwrap() == job_num
+                    && out.instance_id == instance_id
+                    && out.family == "salmon"
+                    && out.region == "ap-south-1"
+                    && out.req_mem == 4096
+                    && out.req_vcpu == 2
+                    && out.bandwidth == 76
+                    && out.eif_url == "https://example.com/enclave.eif"
+            )
+        } else {
+            panic!();
+        };
+
+        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[2] {
             assert_eq!((out.time - spin_up_tv_sec).as_secs(), 50);
             assert!(H256::from_str(&out.job).unwrap() == job_num && out.region == *"ap-south-1")
         } else {
@@ -2096,8 +2196,10 @@ mod tests {
         assert_eq!(res, 0);
         println!("{:?}", aws.outcomes);
         let spin_up_tv_sec: Instant;
+        let instance_id: String;
         if let TestAwsOutcome::SpinUp(out) = &aws.outcomes[0] {
             spin_up_tv_sec = out.time;
+            instance_id = out.instance_id.clone();
             assert!(
                 H256::from_str(&out.job).unwrap() == job_num
                     && out.instance_type == "c6a.xlarge"
@@ -2114,7 +2216,22 @@ mod tests {
             panic!();
         };
 
-        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[1] {
+        if let TestAwsOutcome::RunEnclave(out) = &aws.outcomes[1] {
+            assert!(
+                H256::from_str(&out.job).unwrap() == job_num
+                    && out.instance_id == instance_id
+                    && out.family == "salmon"
+                    && out.region == "ap-south-1"
+                    && out.req_mem == 4096
+                    && out.req_vcpu == 2
+                    && out.bandwidth == 76
+                    && out.eif_url == "https://example.com/enclave.eif"
+            )
+        } else {
+            panic!();
+        };
+
+        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[2] {
             assert_eq!((out.time - spin_up_tv_sec).as_secs(), 200);
             assert!(H256::from_str(&out.job).unwrap() == job_num && out.region == *"ap-south-1")
         } else {
@@ -2251,8 +2368,10 @@ mod tests {
         assert_eq!(res, 0);
         println!("{:?}", aws.outcomes);
         let spin_up_tv_sec: Instant;
+        let instance_id: String;
         if let TestAwsOutcome::SpinUp(out) = &aws.outcomes[0] {
             spin_up_tv_sec = out.time;
+            instance_id = out.instance_id.clone();
             assert!(
                 H256::from_str(&out.job).unwrap() == job_num
                     && out.instance_type == "c6a.xlarge"
@@ -2269,7 +2388,22 @@ mod tests {
             panic!();
         };
 
-        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[1] {
+        if let TestAwsOutcome::RunEnclave(out) = &aws.outcomes[1] {
+            assert!(
+                H256::from_str(&out.job).unwrap() == job_num
+                    && out.instance_id == instance_id
+                    && out.family == "salmon"
+                    && out.region == "ap-south-1"
+                    && out.req_mem == 4096
+                    && out.req_vcpu == 2
+                    && out.bandwidth == 76
+                    && out.eif_url == "https://example.com/enclave.eif"
+            )
+        } else {
+            panic!();
+        };
+
+        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[2] {
             assert_eq!((out.time - spin_up_tv_sec).as_secs(), 200);
             assert!(H256::from_str(&out.job).unwrap() == job_num && out.region == *"ap-south-1")
         } else {
@@ -2517,8 +2651,10 @@ mod tests {
         assert_eq!(res, 0);
         println!("{:?}", aws.outcomes);
         let spin_up_tv_sec: Instant;
+        let instance_id: String;
         if let TestAwsOutcome::SpinUp(out) = &aws.outcomes[0] {
             spin_up_tv_sec = out.time;
+            instance_id = out.instance_id.clone();
             assert!(
                 H256::from_str(&out.job).unwrap() == job_num
                     && out.instance_type == "c6a.xlarge"
@@ -2535,7 +2671,22 @@ mod tests {
             panic!();
         };
 
-        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[1] {
+        if let TestAwsOutcome::RunEnclave(out) = &aws.outcomes[1] {
+            assert!(
+                H256::from_str(&out.job).unwrap() == job_num
+                    && out.instance_id == instance_id
+                    && out.family == "salmon"
+                    && out.region == "ap-south-1"
+                    && out.req_mem == 4096
+                    && out.req_vcpu == 2
+                    && out.bandwidth == 76
+                    && out.eif_url == "https://example.com/updated-enclave.eif"
+            )
+        } else {
+            panic!();
+        };
+
+        if let TestAwsOutcome::SpinDown(out) = &aws.outcomes[2] {
             assert_eq!((out.time - spin_up_tv_sec).as_secs(), 105);
             assert!(H256::from_str(&out.job).unwrap() == job_num && out.region == *"ap-south-1")
         } else {

--- a/src/market.rs
+++ b/src/market.rs
@@ -544,7 +544,6 @@ impl<'a> JobState<'a> {
     }
 
     async fn heartbeat_check(&mut self, mut infra_provider: impl InfraProvider) {
-        // TODO: should check if enclave is running as well
         let job = &self.job_id.id;
         let is_running = infra_provider
             .check_instance_running(&self.instance_id, &self.region)
@@ -1280,7 +1279,6 @@ async fn job_logs(
     contract: Address,
     job: H256,
 ) -> Result<impl Stream<Item = Log> + Send + '_> {
-    // TODO: Filter by contract and job
     let event_filter = Filter::new()
         .select(0..)
         .address(contract)

--- a/src/market.rs
+++ b/src/market.rs
@@ -20,6 +20,15 @@ use ethers::types::Log;
 // One future listening to new jobs
 // Each job has its own future managing its lifetime
 
+// Identify jobs not only by the id, but also by the operator, contract and the chain
+// This is needed to cleanly support multiple operators/contracts/chains at the infra level
+pub struct Job {
+    pub id: String,
+    pub operator: String,
+    pub contract_address: String,
+    pub chain_id: String,
+}
+
 pub trait InfraProvider {
     fn spin_up(
         &mut self,

--- a/src/server.rs
+++ b/src/server.rs
@@ -50,6 +50,7 @@ async fn handle_ip_request(
         &'static [String],
         &'static [RegionalRates],
         &'static [GBRateCard],
+        JobId,
     )>,
     Query(query): Query<GetIPRequest>,
 ) -> HandlerResult<Json<GetIPResponse>> {
@@ -63,10 +64,9 @@ async fn handle_ip_request(
         .get_job_ip(
             &JobId {
                 id: query.id.unwrap(),
-                // TODO: need to store all of this
-                operator: query.region.clone().unwrap(),
-                contract: query.region.clone().unwrap(),
-                chain: query.region.clone().unwrap(),
+                operator: state.4.operator,
+                contract: state.4.contract,
+                chain: state.4.chain,
             },
             &query.region.unwrap(),
         )
@@ -87,6 +87,7 @@ async fn handle_spec_request(
         &'static [String],
         &'static [RegionalRates],
         &'static [GBRateCard],
+        JobId,
     )>,
 ) -> HandlerResult<Json<SpecResponse>> {
     let regions = state.1;
@@ -106,6 +107,7 @@ async fn handle_bandwidth_request(
         &'static [String],
         &'static [RegionalRates],
         &'static [GBRateCard],
+        JobId,
     )>,
 ) -> HandlerResult<Json<BandwidthResponse>> {
     let bandwidth = state.3;
@@ -122,6 +124,7 @@ fn all_routes(
         &'static [String],
         &'static [RegionalRates],
         &'static [GBRateCard],
+        JobId,
     ),
 ) -> Router {
     Router::new()
@@ -137,8 +140,9 @@ pub async fn serve(
     rates: &'static [RegionalRates],
     bandwidth: &'static [GBRateCard],
     addr: SocketAddr,
+    job_id: JobId,
 ) {
-    let state = (client, regions, rates, bandwidth);
+    let state = (client, regions, rates, bandwidth, job_id);
 
     let router = Router::new().merge(all_routes(state));
     println!("Listening for connections on {}", addr);

--- a/src/server.rs
+++ b/src/server.rs
@@ -161,7 +161,7 @@ mod tests {
     use serde_json::json;
     use std::net::SocketAddr;
 
-    use crate::market::{GBRateCard, RateCard, RegionalRates};
+    use crate::market::{GBRateCard, JobId, RateCard, RegionalRates};
     use crate::test::{InstanceMetadata, TestAws};
 
     #[tokio::test]
@@ -182,17 +182,23 @@ mod tests {
         let bandwidth_rates: &'static [GBRateCard] = Box::leak(vec![].into_boxed_slice());
         let port = 8081;
 
+        let job_id = H256::from_low_u64_be(1).encode_hex();
+
         tokio::spawn(serve(
             aws.clone(),
             regions,
             compute_rates,
             bandwidth_rates,
             SocketAddr::from(([0, 0, 0, 0], port)),
+            JobId {
+                id: job_id.clone(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
         ));
 
         let hc = httpc_test::new_client(format!("http://localhost:{}", port))?;
-
-        let job_id = H256::from_low_u64_be(1).encode_hex();
 
         let res = hc
             .do_get(&format!("/ip?id={}&region=ap-south-1", job_id))
@@ -232,17 +238,23 @@ mod tests {
         let bandwidth_rates: &'static [GBRateCard] = Box::leak(vec![].into_boxed_slice());
         let port = 8082;
 
+        let job_id = H256::from_low_u64_be(5).encode_hex();
+
         tokio::spawn(serve(
-            aws,
+            aws.clone(),
             regions,
             compute_rates,
             bandwidth_rates,
             SocketAddr::from(([0, 0, 0, 0], port)),
+            JobId {
+                id: job_id.clone(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
         ));
 
         let hc = httpc_test::new_client(format!("http://localhost:{}", port))?;
-
-        let job_id = H256::from_low_u64_be(5).encode_hex();
 
         let res = hc
             .do_get(&format!("/ip?id={}&region=ap-south-1", job_id))
@@ -270,12 +282,20 @@ mod tests {
         let bandwidth_rates: &'static [GBRateCard] = Box::leak(vec![].into_boxed_slice());
         let port = 8083;
 
+        let job_id = H256::from_low_u64_be(1).encode_hex();
+
         tokio::spawn(serve(
-            aws,
+            aws.clone(),
             regions,
             compute_rates,
             bandwidth_rates,
             SocketAddr::from(([0, 0, 0, 0], port)),
+            JobId {
+                id: job_id.clone(),
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
         ));
 
         let hc = httpc_test::new_client(format!("http://localhost:{}", port))?;
@@ -285,8 +305,6 @@ mod tests {
 
         let body = res.json_body();
         assert!(body.is_ok());
-
-        let job_id = H256::from_low_u64_be(1).encode_hex();
 
         let res = hc
             .do_get(&format!("/ip?id={}&region=ap-south-1", job_id))
@@ -342,12 +360,21 @@ mod tests {
 
         let bandwidth_rates: &'static [GBRateCard] = Box::leak(vec![].into_boxed_slice());
         let port = 8084;
+
+        let job_id = H256::from_low_u64_be(1).encode_hex();
+
         tokio::spawn(serve(
-            aws,
+            aws.clone(),
             regions,
             compute_rates,
             bandwidth_rates,
             SocketAddr::from(([0, 0, 0, 0], port)),
+            JobId {
+                id: job_id,
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
         ));
 
         let hc = httpc_test::new_client(format!("http://localhost:{}", port))?;
@@ -395,12 +422,21 @@ mod tests {
             .into_boxed_slice(),
         );
         let port = 8085;
+
+        let job_id = H256::from_low_u64_be(1).encode_hex();
+
         tokio::spawn(serve(
-            aws,
+            aws.clone(),
             regions,
             compute_rates,
             bandwidth_rates,
             SocketAddr::from(([0, 0, 0, 0], port)),
+            JobId {
+                id: job_id,
+                operator: "abc".into(),
+                contract: "xyz".into(),
+                chain: "123".into(),
+            },
         ));
 
         let hc = httpc_test::new_client(format!("http://localhost:{}", port))?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,7 +8,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
-use crate::market::{GBRateCard, InfraProvider, RegionalRates};
+use crate::market::{GBRateCard, InfraProvider, JobId, RegionalRates};
 
 enum Error {
     GetIPFail,
@@ -60,7 +60,16 @@ async fn handle_ip_request(
     let client = &state.0;
 
     let ip = client
-        .get_job_ip(&query.id.unwrap(), &query.region.unwrap())
+        .get_job_ip(
+            &JobId {
+                id: query.id.unwrap(),
+                // TODO: need to store all of this
+                operator: query.region.clone().unwrap(),
+                contract: query.region.clone().unwrap(),
+                chain: query.region.clone().unwrap(),
+            },
+            &query.region.unwrap(),
+        )
         .await;
 
     if ip.is_err() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -98,7 +98,7 @@ impl InfraProvider for TestAws {
     async fn spin_up(
         &mut self,
         eif_url: &str,
-        job: Job,
+        job: &Job,
         instance_type: &str,
         family: &str,
         region: &str,
@@ -116,8 +116,8 @@ impl InfraProvider for TestAws {
             req_vcpu,
             bandwidth,
             eif_url: eif_url.to_owned(),
-            contract_address: job.contract,
-            chain_id: job.chain,
+            contract_address: job.contract.clone(),
+            chain_id: job.chain.clone(),
         }));
 
         let res = self.instances.get_key_value(&job.id);
@@ -126,7 +126,8 @@ impl InfraProvider for TestAws {
         }
 
         let instance_metadata: InstanceMetadata = InstanceMetadata::new(None, None).await;
-        self.instances.insert(job.id, instance_metadata.clone());
+        self.instances
+            .insert(job.id.clone(), instance_metadata.clone());
 
         Ok(instance_metadata.instance_id)
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -164,16 +164,16 @@ impl InfraProvider for TestAws {
         Ok(instance_metadata.instance_id)
     }
 
-    async fn spin_down(&mut self, instance_id: &str, job: String, region: &str) -> Result<()> {
+    async fn spin_down(&mut self, instance_id: &str, job: &Job, region: &str) -> Result<()> {
         self.outcomes
             .push(TestAwsOutcome::SpinDown(SpinDownOutcome {
                 time: Instant::now(),
-                job: job.clone(),
+                job: job.id.clone(),
                 instance_id: instance_id.to_owned(),
                 region: region.to_owned(),
             }));
 
-        self.instances.remove(&job);
+        self.instances.remove(&job.id);
 
         Ok(())
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use tokio::time::{Duration, Instant};
 use tokio_stream::{Stream, StreamExt};
 
-use crate::market::{GBRateCard, InfraProvider, Job, LogsProvider, RateCard, RegionalRates};
+use crate::market::{GBRateCard, InfraProvider, JobId, LogsProvider, RateCard, RegionalRates};
 
 #[cfg(test)]
 #[derive(Clone, Debug)]
@@ -114,7 +114,7 @@ impl InfraProvider for TestAws {
     async fn spin_up(
         &mut self,
         eif_url: &str,
-        job: &Job,
+        job: &JobId,
         instance_type: &str,
         family: &str,
         region: &str,
@@ -164,7 +164,7 @@ impl InfraProvider for TestAws {
         Ok(instance_metadata.instance_id)
     }
 
-    async fn spin_down(&mut self, instance_id: &str, job: &Job, region: &str) -> Result<()> {
+    async fn spin_down(&mut self, instance_id: &str, job: &JobId, region: &str) -> Result<()> {
         self.outcomes
             .push(TestAwsOutcome::SpinDown(SpinDownOutcome {
                 time: Instant::now(),

--- a/src/test.rs
+++ b/src/test.rs
@@ -32,8 +32,22 @@ pub struct SpinUpOutcome {
 pub struct SpinDownOutcome {
     pub time: Instant,
     pub job: String,
-    pub _instance_id: String,
+    pub instance_id: String,
     pub region: String,
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug)]
+pub struct RunEnclaveOutcome {
+    pub time: Instant,
+    pub job: String,
+    pub instance_id: String,
+    pub family: String,
+    pub region: String,
+    pub eif_url: String,
+    pub req_mem: i64,
+    pub req_vcpu: i32,
+    pub bandwidth: u64,
 }
 
 #[cfg(test)]
@@ -41,6 +55,7 @@ pub struct SpinDownOutcome {
 pub enum TestAwsOutcome {
     SpinUp(SpinUpOutcome),
     SpinDown(SpinDownOutcome),
+    RunEnclave(RunEnclaveOutcome),
 }
 
 #[cfg(test)]
@@ -137,7 +152,7 @@ impl InfraProvider for TestAws {
             .push(TestAwsOutcome::SpinDown(SpinDownOutcome {
                 time: Instant::now(),
                 job: job.clone(),
-                _instance_id: instance_id.to_owned(),
+                instance_id: instance_id.to_owned(),
                 region: region.to_owned(),
             }));
 
@@ -174,15 +189,28 @@ impl InfraProvider for TestAws {
 
     async fn run_enclave(
         &mut self,
-        _job: String,
-        _instance_id: &str,
-        _family: &str,
-        _region: &str,
-        _image_url: &str,
-        _req_vcpu: i32,
-        _req_mem: i64,
-        _bandwidth: u64,
+        job: String,
+        instance_id: &str,
+        family: &str,
+        region: &str,
+        image_url: &str,
+        req_vcpu: i32,
+        req_mem: i64,
+        bandwidth: u64,
     ) -> Result<()> {
+        self.outcomes
+            .push(TestAwsOutcome::RunEnclave(RunEnclaveOutcome {
+                time: Instant::now(),
+                job: job.clone(),
+                instance_id: instance_id.to_owned(),
+                family: family.to_owned(),
+                region: region.to_owned(),
+                eif_url: image_url.to_owned(),
+                req_mem,
+                req_vcpu,
+                bandwidth,
+            }));
+
         Ok(())
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -178,8 +178,8 @@ impl InfraProvider for TestAws {
         Ok(())
     }
 
-    async fn get_job_instance(&self, job: &str, _region: &str) -> Result<(bool, String, String)> {
-        let res = self.instances.get_key_value(job);
+    async fn get_job_instance(&self, job: &JobId, _region: &str) -> Result<(bool, String, String)> {
+        let res = self.instances.get_key_value(&job.id);
         if let Some(x) = res {
             return Ok((true, x.1.instance_id.clone(), "running".to_owned()));
         }
@@ -187,12 +187,12 @@ impl InfraProvider for TestAws {
         Ok((false, String::new(), String::new()))
     }
 
-    async fn get_job_ip(&self, job_id: &str, _region: &str) -> Result<String> {
-        let instance_metadata = self.instances.get(job_id);
+    async fn get_job_ip(&self, job: &JobId, _region: &str) -> Result<String> {
+        let instance_metadata = self.instances.get(&job.id);
         if instance_metadata.is_some() {
             return Ok(instance_metadata.unwrap().ip_address.clone());
         }
-        return Err(anyhow!("Instance not found for job - {job_id}"));
+        return Err(anyhow!("Instance not found for job - {}", job.id));
     }
 
     async fn check_instance_running(&mut self, _instance_id: &str, _region: &str) -> Result<bool> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -206,7 +206,7 @@ impl InfraProvider for TestAws {
 
     async fn run_enclave(
         &mut self,
-        job: String,
+        job: &JobId,
         instance_id: &str,
         family: &str,
         region: &str,
@@ -218,7 +218,7 @@ impl InfraProvider for TestAws {
         self.outcomes
             .push(TestAwsOutcome::RunEnclave(RunEnclaveOutcome {
                 time: Instant::now(),
-                job: job.clone(),
+                job: job.id.clone(),
                 instance_id: instance_id.to_owned(),
                 family: family.to_owned(),
                 region: region.to_owned(),

--- a/src/test.rs
+++ b/src/test.rs
@@ -116,8 +116,8 @@ impl InfraProvider for TestAws {
             req_vcpu,
             bandwidth,
             eif_url: eif_url.to_owned(),
-            contract_address: job.contract_address,
-            chain_id: job.chain_id,
+            contract_address: job.contract,
+            chain_id: job.chain,
         }));
 
         let res = self.instances.get_key_value(&job.id);


### PR DESCRIPTION
Tags and filters were inconsistent in terms of applying all necessary fields. The current fields allow multiplexing jobs across operators, contracts, and chains in the same underlying account.

Tests check for RunEnclave calls as well now.